### PR TITLE
Added ClrRuntimeSymbolResolver

### DIFF
--- a/src/JitBuddy.Tests/ClrRuntimeNameResolverTests.cs
+++ b/src/JitBuddy.Tests/ClrRuntimeNameResolverTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace JitBuddy.Tests
+{
+    [TestFixture]
+    public class ClrRuntimeNameResolverTests
+    {
+        [Test]
+        public void ResolveSymbolTest()
+        {
+            var method = typeof(Foo).GetMethod("FooMethod");
+            var result = method.ToAsm();
+            Console.WriteLine(result);
+            Assert.IsNotEmpty(result);
+            Assert.That(result, Contains.Substring("JitBuddy.Tests.ClrRuntimeNameResolverTests+Bar.BarMethod()"));
+        }
+
+        class Foo
+        {
+            public void FooMethod(Bar b)
+            {
+                b.BarMethod();
+            }
+        }
+
+        class Bar
+        {
+            public void BarMethod()
+            {
+            }
+        }
+    }
+}

--- a/src/JitBuddy/ClrRuntimeSymbolResolver.cs
+++ b/src/JitBuddy/ClrRuntimeSymbolResolver.cs
@@ -1,0 +1,29 @@
+﻿using Iced.Intel;
+using Microsoft.Diagnostics.Runtime;
+
+namespace JitBuddy
+{
+    internal class ClrRuntimeSymbolResolver : ISymbolResolver
+    {
+        private readonly ClrRuntime _runtime;
+
+        public ClrRuntimeSymbolResolver(ClrRuntime runtime)
+        {
+            _runtime = runtime;
+        }
+
+        public bool TryGetSymbol(in Instruction instruction, int operand, int instructionOperand,
+            ulong address, int addressSize, out SymbolResult symbol)
+        {
+            ClrMethod method = _runtime.GetMethodByInstructionPointer(address);
+
+            if (method != null && !string.IsNullOrEmpty(method.Signature))
+            {
+                symbol = new SymbolResult(address, method.Signature);
+                return true;
+            }
+            symbol = default;
+            return false;
+        }
+    }
+}

--- a/src/JitBuddy/JitBuddy.cs
+++ b/src/JitBuddy/JitBuddy.cs
@@ -57,12 +57,21 @@ namespace JitBuddy
                 var codePtr = clrmdMethodHandle.HotColdInfo.HotStart;
                 var codeSize = clrmdMethodHandle.HotColdInfo.HotSize;
 
+                // Formatters: Masm*, Nasm* and Gas* (AT&T)
+                if (formatter == null)
+                {
+                    var symbolResolver = new ClrRuntimeSymbolResolver(runtime);
+                    formatter = new NasmFormatter(symbolResolver);
+                    formatter.Options.DigitSeparator = "`";
+                    formatter.Options.FirstOperandCharIndex = 10;
+                }
+
                 // Disassemble with Iced
                 DecodeMethod(new IntPtr((long)codePtr), codeSize, builder, formatter);
             }
         }
 
-        private static void DecodeMethod(IntPtr ptr, uint size, StringBuilder builder, Formatter formatter = null)
+        private static void DecodeMethod(IntPtr ptr, uint size, StringBuilder builder, Formatter formatter)
         {
             // You can also pass in a hex string, eg. "90 91 929394", or you can use your own CodeReader
             // reading data from a file or memory etc.
@@ -82,13 +91,6 @@ namespace JitBuddy
                 decoder.Decode(out instructions.AllocUninitializedElement());
             }
 
-            // Formatters: Masm*, Nasm* and Gas* (AT&T)
-            if (formatter == null)
-            {
-                formatter = new NasmFormatter();
-                formatter.Options.DigitSeparator = "`";
-                formatter.Options.FirstOperandCharIndex = 10;
-            }
             var output = new StringOutput();
             // Use InstructionList's ref iterator (C# 7.3) to prevent copying 32 bytes every iteration
             foreach (ref var instr in instructions)


### PR DESCRIPTION
Added ClrRuntime symbol resolver when no formatter specified.

Before:
`00007FFE53A5BE57 call      00007FFEB2F3D4F0h`
After:
`00007FFE53A5BE57 call      JitBuddy.Foo.Bar()`